### PR TITLE
Upgrade Testcontainers to 2.0.4

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 ### Development
 
+- upgrade testcontainers from 1.21.3 to 2.0.4
 - remove testLibs version catalog and combine with libs
 
 ## 2025-09-25 / 1.3.0

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -75,7 +75,6 @@ dependencies {
     // TestContainers
     testFixturesCompileOnly(libs.kotest.framework.api)
     testFixturesImplementation(libs.testcontainers.kafka)
-    testFixturesImplementation(libs.commons.codec) // required for testcontainers-kafka
     testFixturesImplementation(mn.kotlin.reflect)
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,11 +1,10 @@
 [versions]
 micronaut = "4.9.3"
-commons-codec = "1.19.0"
 kafka-clients = "3.9.1"
 kotest = "5.9.1"
 kotlin-logging = "7.0.13"
 logstash = "8.1"
-testcontainers = "1.21.3"
+testcontainers = "2.0.4"
 
 detekt = "1.23.8"
 lovely-gradle = "1.16.0"
@@ -18,8 +17,7 @@ kotest-framework-api = { module = "io.kotest:kotest-framework-api-jvm", version.
 kotest-assertions-core = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }
 kotlin-logging = { module = "io.github.oshai:kotlin-logging-jvm", version.ref = "kotlin-logging" }
 logstash-logback-encoder = { module = "net.logstash.logback:logstash-logback-encoder", version.ref = "logstash" }
-testcontainers-kafka = { module = "org.testcontainers:kafka", version.ref = "testcontainers" }
-commons-codec = { module = "commons-codec:commons-codec", version.ref = "commons-codec" }
+testcontainers-kafka = { module = "org.testcontainers:testcontainers-kafka", version.ref = "testcontainers" }
 kafka-clients = { module = "org.apache.kafka:kafka-clients", version.ref = "kafka-clients" }
 
 [plugins]


### PR DESCRIPTION
Testcontainers works with Docker 29+ without the `api.version` workaround, and the Kafka module artifact follows TC 2.x naming.

## What

- Upgrade Testcontainers from 1.21.3 to 2.0.4
- Rename artifact `org.testcontainers:kafka` → `org.testcontainers:testcontainers-kafka` (TC 2.x convention)
- Drop explicit `commons-codec` dependency — now transitive via TC 2.x

## Risks

- None identified — no code changes, existing `KafkaExtension` already used TC 2.x–compatible APIs, all tests pass

## AI Attribution

- 2 of 2 commits co-authored with Claude
- Version bump, artifact rename, dependency cleanup

## References

- [OP-14666](https://lovely.myjetbrains.com/youtrack/issue/OP-14666) — Upgrade Testcontainers to 2.x

---

#lovelyreviewdesc | base: f479354 | head: 72d0b0a